### PR TITLE
Add fallback for mutation observer in older browsers.

### DIFF
--- a/index.js
+++ b/index.js
@@ -164,7 +164,6 @@ var NavigationEmitter = function () {
         this._keyEndListener = onKeyEnd.bind(model);
         this._clickListener = onClick.bind(model);
         this._focusExitListener = onFocusExit.bind(model);
-        this._observer = new MutationObserver(onMutation.bind(model));
 
         setData(model.items);
 
@@ -180,7 +179,7 @@ var NavigationEmitter = function () {
         el.addEventListener('click', this._clickListener);
         el.addEventListener('focusExit', this._focusExitListener);
 
-        this._observer.observe(el, { childList: true, subtree: true });
+        Util.watchSubtree(el, onMutation.bind(model));
     }
 
     _createClass(NavigationEmitter, null, [{

--- a/src/index.js
+++ b/src/index.js
@@ -141,7 +141,6 @@ class NavigationEmitter {
         this._keyEndListener = onKeyEnd.bind(model);
         this._clickListener = onClick.bind(model);
         this._focusExitListener = onFocusExit.bind(model);
-        this._observer = new MutationObserver(onMutation.bind(model));
 
         setData(model.items);
 
@@ -157,7 +156,7 @@ class NavigationEmitter {
         el.addEventListener('click', this._clickListener);
         el.addEventListener('focusExit', this._focusExitListener);
 
-        this._observer.observe(el, { childList: true, subtree: true });
+        Util.watchSubtree(el, onMutation.bind(model));
     }
 
     static createLinear(el, itemSelector, selectedOptions) {

--- a/src/util.js
+++ b/src/util.js
@@ -1,7 +1,31 @@
+let watchSubtree;
+
+if (typeof window !== 'undefined') {
+    const raf = window.requestAnimationFrame || setTimeout;
+    if (window.MutationObserver) {
+        const opts = { childList: true, subtree: true };
+        watchSubtree = (el, cb) => {
+            const observer = new MutationObserver(cb);
+            observer.observe(el, opts);
+        };
+    } else {
+        watchSubtree = (el, cb) => {
+            el.addEventListener('DOMSubtreeModified', function handler() {
+                el.removeEventListener('DOMSubtreeModified', handler);
+                raf(() => {
+                    cb();
+                    el.addEventListener('DOMSubtreeModified', handler);
+                });
+            });
+        };
+    }
+}
+
 function nodeListToArray(nodeList) {
     return Array.prototype.slice.call(nodeList);
 }
 
 module.exports = {
-    nodeListToArray
+    nodeListToArray,
+    watchSubtree
 };

--- a/test/static/bundle-module.js
+++ b/test/static/bundle-module.js
@@ -46,14 +46,42 @@ try {
 }
 
 });
+<<<<<<< HEAD
 $_mod.def("/makeup-navigation-emitter$0.0.6/util", function(require, exports, module, __filename, __dirname) { "use strict";
+=======
+$_mod.def("/makeup-navigation-emitter$0.0.5/util", function(require, exports, module, __filename, __dirname) { 'use strict';
+
+var watchSubtree = void 0;
+
+if (typeof window !== 'undefined') {
+    var raf = window.requestAnimationFrame || setTimeout;
+    if (window.MutationObserver) {
+        var opts = { childList: true, subtree: true };
+        watchSubtree = function watchSubtree(el, cb) {
+            var observer = new MutationObserver(cb);
+            observer.observe(el, opts);
+        };
+    } else {
+        watchSubtree = function watchSubtree(el, cb) {
+            el.addEventListener('DOMSubtreeModified', function handler() {
+                el.removeEventListener('DOMSubtreeModified', handler);
+                raf(function () {
+                    cb();
+                    el.addEventListener('DOMSubtreeModified', handler);
+                });
+            });
+        };
+    }
+}
+>>>>>>> Add fallback for mutation observer in older browsers.
 
 function nodeListToArray(nodeList) {
     return Array.prototype.slice.call(nodeList);
 }
 
 module.exports = {
-    nodeListToArray: nodeListToArray
+    nodeListToArray: nodeListToArray,
+    watchSubtree: watchSubtree
 };
 
 });
@@ -463,7 +491,6 @@ var NavigationEmitter = function () {
         this._keyEndListener = onKeyEnd.bind(model);
         this._clickListener = onClick.bind(model);
         this._focusExitListener = onFocusExit.bind(model);
-        this._observer = new MutationObserver(onMutation.bind(model));
 
         setData(model.items);
 
@@ -479,7 +506,7 @@ var NavigationEmitter = function () {
         el.addEventListener('click', this._clickListener);
         el.addEventListener('focusExit', this._focusExitListener);
 
-        this._observer.observe(el, { childList: true, subtree: true });
+        Util.watchSubtree(el, onMutation.bind(model));
     }
 
     _createClass(NavigationEmitter, null, [{

--- a/util.js
+++ b/util.js
@@ -1,9 +1,33 @@
-"use strict";
+'use strict';
+
+var watchSubtree = void 0;
+
+if (typeof window !== 'undefined') {
+    var raf = window.requestAnimationFrame || setTimeout;
+    if (window.MutationObserver) {
+        var opts = { childList: true, subtree: true };
+        watchSubtree = function watchSubtree(el, cb) {
+            var observer = new MutationObserver(cb);
+            observer.observe(el, opts);
+        };
+    } else {
+        watchSubtree = function watchSubtree(el, cb) {
+            el.addEventListener('DOMSubtreeModified', function handler() {
+                el.removeEventListener('DOMSubtreeModified', handler);
+                raf(function () {
+                    cb();
+                    el.addEventListener('DOMSubtreeModified', handler);
+                });
+            });
+        };
+    }
+}
 
 function nodeListToArray(nodeList) {
     return Array.prototype.slice.call(nodeList);
 }
 
 module.exports = {
-    nodeListToArray: nodeListToArray
+    nodeListToArray: nodeListToArray,
+    watchSubtree: watchSubtree
 };


### PR DESCRIPTION
Falls back to `DOMSubtreeModified` in older browsers (ie: 9 & 10).